### PR TITLE
Add fuse setting capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
 __pycache__
+*.pyc

--- a/device/device.py
+++ b/device/device.py
@@ -1,16 +1,29 @@
-
-
 class Device(object): # pylint: disable=too-few-public-methods
     """
     Contains device specific information needed for programming
     """
     def __init__(self, device_name):
-        if device_name == "tiny817":
+        if device_name == "tiny817" or device_name == "tiny816" or device_name == "tiny814":
             self.flash_start = 0x8000
             self.flash_size = 8 * 1024
             self.flash_pagesize = 64
+            self.syscfg_address = 0x0F00
             self.nvmctrl_address = 0x1000
             self.sigrow_address = 0x1100
+            self.fuses_address = 0x1280
+            self.userrow_address = 0x1300
+        elif device_name == "tiny417":
+            self.flash_start = 0x8000
+            self.flash_size = 4 * 1024
+            self.flash_pagesize = 64
             self.syscfg_address = 0x0F00
+            self.nvmctrl_address = 0x1000
+            self.sigrow_address = 0x1100
+            self.fuses_address = 0x1280
+            self.userrow_address = 0x1300
         else:
             raise Exception("Unknown device")
+
+    @staticmethod
+    def get_supported_devices():
+        return ["tiny817", "tiny816", "tiny814", "tiny417"]

--- a/pyupdi.py
+++ b/pyupdi.py
@@ -1,9 +1,12 @@
-
-import logging
-
+#!/usr/bin/env python
 from device.device import Device
 from updi.nvm import UpdiNvmProgrammer
 
+import sys
+import argparse
+import re
+
+import logging
 """
 Copyright (c) 2016 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
 
@@ -48,53 +51,100 @@ pyupdi is a Python utility for programming AVR devices with UPDI interface
 
 """
 
-"""
-    Simple command line interface for programming flash
-"""
-if __name__ == "__main__":
-    # Simple command line interface for demo purposes
-    import sys
+def _main():
+    parser = argparse.ArgumentParser(description="Simple command line"
+                                     " interface for UPDI programming")
+    parser.add_argument("-d", "--device", choices=Device.get_supported_devices(),
+                        required=True, help="Target device")
+    parser.add_argument("-c", "--comport", required=True,
+                        help="Com port to use (Windows: COMx | *nix: /dev/ttyX)")
+    parser.add_argument("-e", "--erase", action="store_true",
+                        help="Perform a chip erase (implied with --flash)")
+    parser.add_argument("-b", "--baudrate", type=int, default=115200)
+    parser.add_argument("-f", "--flash", help="Intel HEX file to flash.")
+    parser.add_argument("-fs", "--fuses", action="append", nargs="*",
+                        help="Fuse to set (syntax: fuse_nr:0xvalue)")
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        help="Set verbose mode")
 
-    if len(sys.argv) != 4:
-        print("Python UPDI programmer demo")
-        print("Usage: pyupdi.py comport device filename")
-        sys.exit(1)
+    args = parser.parse_args(sys.argv[1:])
 
-    logging.basicConfig(format="%(levelname)s:%(name)s %(message)s",
-                        level=logging.WARNING)
+    if args.fuses is None and args.flash is None and not args.erase:
+        print("No action (erase, flash or fuses)")
+        sys.exit(0)
 
-    # Retrieve parameters
-    comport = sys.argv[1]
-    device = Device(sys.argv[2])
-    filename = sys.argv[3]
+    if args.verbose:
+        logging.basicConfig(format="%(levelname)s:%(name)s %(message)s",
+                            level=logging.INFO)
+    else:
+        logging.basicConfig(format="%(levelname)s:%(name)s %(message)s",
+                            level=logging.WARNING)
 
-    nvm = UpdiNvmProgrammer(comport=comport, baud=115200, device=device)
+    nvm = UpdiNvmProgrammer(comport=args.comport,
+                            baud=args.baudrate,
+                            device=Device(args.device))
 
-    # Retrieve data to write
-    data, start_address = nvm.load_ihex(filename)
-
-    # Enter programming mode
     try:
         nvm.enter_progmode()
-    except Exception:
-        print("Device is locked.  Performing unlock with chip erase.")
+    except:
+        print("Device is locked. Performing unlock with chip erase.")
         nvm.unlock_device()
 
-    # Read and display device info
     nvm.get_device_info()
 
-    # Erase the device
-    nvm.chip_erase()
+    if not _process(nvm, args):
+        print("Error during processing")
 
-    # Program from intel hex file
+    nvm.leave_progmode()
+
+def _process(nvm, args):
+    if args.erase:
+        try:
+            nvm.chip_erase()
+        except:
+            return False
+    if args.fuses is not None:
+        for fslist in args.fuses:
+            for fsarg in fslist:
+                if not re.match("^[0-9]+:0x[0-9a-fA-F]+$", fsarg):
+                    print("Bad fuses format {}. Expected fuse_nr:0xvalue".format(fsarg))
+                    continue
+                lst = fsarg.split(":0x")
+                fusenum = int(lst[0])
+                value = int(lst[1], 16)
+                if not _set_fuse(nvm, fusenum, value):
+                    return False
+    if args.flash is not None:
+        return _flash_file(nvm, args.flash)
+    return True
+
+def _flash_file(nvm, filename):
+    data, start_address = nvm.load_ihex(filename)
+
+    fail=False
+
+    nvm.chip_erase()
     nvm.write_flash(start_address, data)
 
     # Read out again
-    readback = nvm.read_flash(device.flash_start, len(data))
+    readback = nvm.read_flash(nvm.device.flash_start, len(data))
     for i, _ in enumerate(data):
         if data[i] != readback[i]:
-            print("Verify error at location 0x{0:04X}: expected 0x{1:02X} read 0x{2:02X} ".format(i, data[i],
-                                                                                                  readback[i]))
+            print("Verify error at location 0x{0:04X}: expected 0x{1:02X} read 0x{2:02X} ".format(i, data[i], readback[i]))
+            fail=True
 
-    # Exit programming mode
-    nvm.leave_progmode()
+    if not fail:
+        print("Programming successful")
+    return not fail
+
+
+def _set_fuse(nvm, fusenum, value):
+    nvm.write_fuse(fusenum, value)
+    actual_val = nvm.read_fuse(fusenum)
+    ret = actual_val == value
+    if not ret:
+        print("Verify error for fuse {0}, expected 0x{1:02X} read 0x{2:02X}".format(fusenum, value, actual_val))
+    return ret
+
+if __name__ == "__main__":
+    _main()

--- a/updi/physical.py
+++ b/updi/physical.py
@@ -1,4 +1,3 @@
-
 import logging
 import time
 import serial
@@ -31,6 +30,14 @@ class UpdiPhysical(object):
 
         self.logger.info("Opening {} at {} baud".format(port, baud))
         self.ser = serial.Serial(port, baud, parity=serial.PARITY_EVEN, timeout=1, stopbits=serial.STOPBITS_TWO)
+
+    def _loginfo(self, msg, data):
+        if data and isinstance(data[0], str):
+            i_data = [ord(x) for x in data]
+        else:
+            i_data = data
+        data_str = "[" + ", ".join([hex(x) for x in i_data]) + "]"
+        self.logger.info(msg + ' : ' + data_str)
 
     def send_double_break(self):
         """
@@ -65,7 +72,7 @@ class UpdiPhysical(object):
             Sends a char array to UPDI with inter-byte delay
             Note that the byte will echo back
         """
-        self.logger.info("send: {}".format(command))
+        self._loginfo("send", command)
 
         for character in command:
 
@@ -98,7 +105,7 @@ class UpdiPhysical(object):
             else:
                 timeout -= 1
 
-        self.logger.info("receive: {}".format(response))
+        self._loginfo("receive", response)
         return response
 
     def sib(self):


### PR DESCRIPTION
This introduce the following changes:

- Possibility to set fuses on the target
- More "user friendly" command line interface using the argparse module (with a proper --help)
- Support for other devices (based on the datasheet content)

Tested from linux, using a 3.3V FTDI chip and a ATTiny817 XMINI board