### PR TITLE
Add support for ATTINY214 and ATTINY414

### DIFF
--- a/device/device.py
+++ b/device/device.py
@@ -12,9 +12,18 @@ class Device(object):  # pylint: disable=too-few-public-methods
             self.sigrow_address = 0x1100
             self.fuses_address = 0x1280
             self.userrow_address = 0x1300
-        elif device_name == "tiny417":
+        elif device_name == "tiny417" or device_name == "tiny414":
             self.flash_start = 0x8000
             self.flash_size = 4 * 1024
+            self.flash_pagesize = 64
+            self.syscfg_address = 0x0F00
+            self.nvmctrl_address = 0x1000
+            self.sigrow_address = 0x1100
+            self.fuses_address = 0x1280
+            self.userrow_address = 0x1300
+        elif device_name == "tiny214":
+            self.flash_start = 0x8000
+            self.flash_size = 2 * 1024
             self.flash_pagesize = 64
             self.syscfg_address = 0x0F00
             self.nvmctrl_address = 0x1000
@@ -26,4 +35,4 @@ class Device(object):  # pylint: disable=too-few-public-methods
 
     @staticmethod
     def get_supported_devices():
-        return ["tiny817", "tiny816", "tiny814", "tiny417"]
+        return ["tiny817", "tiny816", "tiny814", "tiny417", "tiny414", "tiny214"]


### PR DESCRIPTION
Add support for ATTINY214 and ATTINY414. They are similar to ATTINY814, but with 2/4KB flash, respectively.
Tested successfully with an ATTINY214. The ATTINY414 should work aswell.