### PR TITLE
Add support for ATtiny412

### DIFF
--- a/device/device.py
+++ b/device/device.py
@@ -12,7 +12,7 @@ class Device(object):  # pylint: disable=too-few-public-methods
             self.sigrow_address = 0x1100
             self.fuses_address = 0x1280
             self.userrow_address = 0x1300
-        elif device_name == "tiny417" or device_name == "tiny414":
+        elif device_name == "tiny417" or device_name == "tiny414" or device_name == "tiny412":
             self.flash_start = 0x8000
             self.flash_size = 4 * 1024
             self.flash_pagesize = 64
@@ -35,4 +35,4 @@ class Device(object):  # pylint: disable=too-few-public-methods
 
     @staticmethod
     def get_supported_devices():
-        return ["tiny817", "tiny816", "tiny814", "tiny417", "tiny414", "tiny214"]
+        return ["tiny817", "tiny816", "tiny814", "tiny417", "tiny414", "tiny412", "tiny214"]


### PR DESCRIPTION
I have verified that the settings for the ATtiny417 and ATtiny414 also apply to the ATtiny412. Programming works as expected, it should therefore be added to list of supported devices.