### PR TITLE
ATtiny202/204/402/404/406 support

### DIFF
--- a/device/device.py
+++ b/device/device.py
@@ -1,9 +1,13 @@
+DEVICES_8K = set(["tiny814", "tiny817"])
+DEVICES_4K = set(["tiny402", "tiny404", "tiny406", "tiny412", "tiny414", "tiny417"])
+DEVICES_2K = set(["tiny202", "tiny204", "tiny214"])
+
 class Device(object):  # pylint: disable=too-few-public-methods
     """
     Contains device specific information needed for programming
     """
     def __init__(self, device_name):
-        if device_name == "tiny817" or device_name == "tiny816" or device_name == "tiny814":
+        if device_name in DEVICES_8K:
             self.flash_start = 0x8000
             self.flash_size = 8 * 1024
             self.flash_pagesize = 64
@@ -12,7 +16,7 @@ class Device(object):  # pylint: disable=too-few-public-methods
             self.sigrow_address = 0x1100
             self.fuses_address = 0x1280
             self.userrow_address = 0x1300
-        elif device_name == "tiny417" or device_name == "tiny414" or device_name == "tiny412":
+        elif device_name in DEVICES_4K:
             self.flash_start = 0x8000
             self.flash_size = 4 * 1024
             self.flash_pagesize = 64
@@ -21,7 +25,7 @@ class Device(object):  # pylint: disable=too-few-public-methods
             self.sigrow_address = 0x1100
             self.fuses_address = 0x1280
             self.userrow_address = 0x1300
-        elif device_name == "tiny214":
+        elif device_name in DEVICES_2K:
             self.flash_start = 0x8000
             self.flash_size = 2 * 1024
             self.flash_pagesize = 64
@@ -35,4 +39,4 @@ class Device(object):  # pylint: disable=too-few-public-methods
 
     @staticmethod
     def get_supported_devices():
-        return ["tiny817", "tiny816", "tiny814", "tiny417", "tiny414", "tiny412", "tiny214"]
+        return sorted(DEVICES_2K | DEVICES_4K | DEVICES_8K)


### PR DESCRIPTION
Add support for the 0-series of tinyAVR parts. Tested to work with ATtiny404 (and I'll be able to test with an ATtiny204 later today.)