### PR TITLE
HV mode

### DIFF
--- a/pyupdi.py
+++ b/pyupdi.py
@@ -69,7 +69,7 @@ def _main():
     parser.add_argument("-b", "--baudrate", type=int, default=115200)
     parser.add_argument("-f", "--flash", help="Intel HEX file to flash.")
     parser.add_argument("-hv", "--hv-init",
-                        help="Use high voltage UPDI initiation protocol")
+                        help="Use high voltage (syntax: dtr | gpio:[-]portnum where - signifies active low output)")
     parser.add_argument("-r", "--reset", action="store_true",
                         help="Reset")
     parser.add_argument("-fs", "--fuses", action="append", nargs="*",

--- a/pyupdi.py
+++ b/pyupdi.py
@@ -68,8 +68,8 @@ def _main():
                         help="Perform a chip erase (implied with --flash)")
     parser.add_argument("-b", "--baudrate", type=int, default=115200)
     parser.add_argument("-f", "--flash", help="Intel HEX file to flash.")
-    parser.add_argument("-pd", "--pulse-dtr", type=int, default=0,
-                        help="Pulse DTR for this many ms upon opening port")
+    parser.add_argument("-hv", "--hv-init",
+                        help="Use high voltage UPDI initiation protocol")
     parser.add_argument("-r", "--reset", action="store_true",
                         help="Reset")
     parser.add_argument("-fs", "--fuses", action="append", nargs="*",
@@ -95,7 +95,7 @@ def _main():
     nvm = UpdiNvmProgrammer(comport=args.comport,
                             baud=args.baudrate,
                             device=Device(args.device),
-                            dtr=args.pulse_dtr)
+                            hv=args.hv_init)
     if not args.reset: # any action except reset
         try:
             nvm.enter_progmode()

--- a/pyupdi.py
+++ b/pyupdi.py
@@ -68,6 +68,8 @@ def _main():
                         help="Perform a chip erase (implied with --flash)")
     parser.add_argument("-b", "--baudrate", type=int, default=115200)
     parser.add_argument("-f", "--flash", help="Intel HEX file to flash.")
+    parser.add_argument("-pd", "--pulse-dtr", type=int, default=0,
+                        help="Pulse DTR for this many ms upon opening port")
     parser.add_argument("-r", "--reset", action="store_true",
                         help="Reset")
     parser.add_argument("-fs", "--fuses", action="append", nargs="*",
@@ -92,7 +94,8 @@ def _main():
 
     nvm = UpdiNvmProgrammer(comport=args.comport,
                             baud=args.baudrate,
-                            device=Device(args.device))
+                            device=Device(args.device),
+                            dtr=args.pulse_dtr)
     if not args.reset: # any action except reset
         try:
             nvm.enter_progmode()

--- a/updi/application.py
+++ b/updi/application.py
@@ -13,8 +13,8 @@ class UpdiApplication(object):
         Generic application layer for UPDI
     """
 
-    def __init__(self, comport, baud, device=None):
-        self.datalink = UpdiDatalink(comport, baud)
+    def __init__(self, comport, baud, device=None, dtr=0):
+        self.datalink = UpdiDatalink(comport, baud, dtr)
         self.device = device
 
         self.logger = logging.getLogger("app")

--- a/updi/application.py
+++ b/updi/application.py
@@ -13,8 +13,8 @@ class UpdiApplication(object):
         Generic application layer for UPDI
     """
 
-    def __init__(self, comport, baud, device=None, dtr=0):
-        self.datalink = UpdiDatalink(comport, baud, dtr)
+    def __init__(self, comport, baud, device=None, hv=None):
+        self.datalink = UpdiDatalink(comport, baud, hv)
         self.device = device
 
         self.logger = logging.getLogger("app")

--- a/updi/link.py
+++ b/updi/link.py
@@ -13,11 +13,11 @@ class UpdiDatalink(object):
         UPDI data link class handles the UPDI data protocol within the device
     """
 
-    def __init__(self, comport, baud, dtr):
+    def __init__(self, comport, baud, hv):
         self.logger = logging.getLogger("link")
 
         # Create a UPDI physical connection
-        self.updi_phy = UpdiPhysical(comport, baud, dtr)
+        self.updi_phy = UpdiPhysical(comport, baud, hv)
 
         # Initialise
         self.init()

--- a/updi/link.py
+++ b/updi/link.py
@@ -13,11 +13,11 @@ class UpdiDatalink(object):
         UPDI data link class handles the UPDI data protocol within the device
     """
 
-    def __init__(self, comport, baud):
+    def __init__(self, comport, baud, dtr):
         self.logger = logging.getLogger("link")
 
         # Create a UPDI physical connection
-        self.updi_phy = UpdiPhysical(comport, baud)
+        self.updi_phy = UpdiPhysical(comport, baud, dtr)
 
         # Initialise
         self.init()
@@ -213,3 +213,4 @@ class UpdiDatalink(object):
             raise Exception("Invalid KEY length!")
         self.updi_phy.send([constants.UPDI_PHY_SYNC, constants.UPDI_KEY | constants.UPDI_KEY_KEY | size])
         self.updi_phy.send(list(reversed(list(key))))
+

--- a/updi/nvm.py
+++ b/updi/nvm.py
@@ -12,9 +12,9 @@ class UpdiNvmProgrammer(object):
         NVM programming utility for UPDI
     """
 
-    def __init__(self, comport, baud, device):
+    def __init__(self, comport, baud, device, dtr):
 
-        self.application = UpdiApplication(comport, baud, device)
+        self.application = UpdiApplication(comport, baud, device, dtr)
         self.device = device
         self.progmode = False
         self.logger = logging.getLogger("nvm")

--- a/updi/nvm.py
+++ b/updi/nvm.py
@@ -12,9 +12,9 @@ class UpdiNvmProgrammer(object):
         NVM programming utility for UPDI
     """
 
-    def __init__(self, comport, baud, device, dtr):
+    def __init__(self, comport, baud, device, hv):
 
-        self.application = UpdiApplication(comport, baud, device, dtr)
+        self.application = UpdiApplication(comport, baud, device, hv)
         self.device = device
         self.progmode = False
         self.logger = logging.getLogger("nvm")

--- a/updi/physical.py
+++ b/updi/physical.py
@@ -25,11 +25,10 @@ class UpdiPhysical(object):
         self.ibdly = 0.0001
         self.port = port
         self.baud = baud
-        if hv:
-            (self.hvtype, _, self.hvinfo) = hv.partition(":")
         self.ser = None
         self.initialise_serial(self.port, self.baud)
         if hv:
+            (self.hvtype, _, self.hvinfo) = hv.partition(":")
             self.send_hv()
             time.sleep(0.002)
         # send an initial break as handshake

--- a/updi/physical.py
+++ b/updi/physical.py
@@ -81,7 +81,7 @@ class UpdiPhysical(object):
         if (self.hvtype == 'dtr'):
             self.logger.info("Pulsing DTR")
             self.ser.dtr = True
-            time.sleep(0.002)
+            time.sleep(0.01)
             self.ser.dtr = False
         elif (self.hvtype == 'gpio'):
             if not gpio:

--- a/updi/physical.py
+++ b/updi/physical.py
@@ -13,7 +13,7 @@ class UpdiPhysical(object):
         PDI physical driver using a given COM port at a given baud
     """
 
-    def __init__(self, port, baud=115200):
+    def __init__(self, port, baud=115200, dtr=0):
         """
             Initialise the COM port
         """
@@ -26,6 +26,8 @@ class UpdiPhysical(object):
         self.baud = baud
         self.ser = None
         self.initialise_serial(self.port, self.baud)
+        if dtr > 0:
+            self.pulse_dtr(dtr)
         # send an initial break as handshake
         self.send([constants.UPDI_BREAK])
 
@@ -70,6 +72,15 @@ class UpdiPhysical(object):
         temporary_serial.close()
         self.initialise_serial(self.port, self.baud)
 
+    def pulse_dtr(self, ms):
+        """
+            Pulse DTR to enable 12V
+        """
+        self.logger.info("Pulsing DTR")
+        self.ser.dtr = True
+        time.sleep(ms/1000)
+        self.ser.dtr = False
+        
     def send(self, command):
         """
             Sends a char array to UPDI with inter-byte delay

--- a/updi/physical.py
+++ b/updi/physical.py
@@ -84,7 +84,12 @@ class UpdiPhysical(object):
             time.sleep(0.002)
             self.ser.dtr = False
         elif (self.hvtype == 'gpio'):
-            gpiopin = abs(int(self.hvinfo))
+            if not gpio:
+                raise Exception("GPIO HV requested and gpio module not installed. pip install gpio");
+            try:
+                gpiopin = abs(int(self.hvinfo))
+            except:
+                raise Exception("GPIO HV requested and no portnum given")
             gpioneg = self.hvinfo.startswith("-")
             gpio.setup(gpiopin, gpio.OUT, initial=gpioneg)
             gpio.set(gpiopin, not gpioneg)


### PR DESCRIPTION
This patch adds an -hv command line argument which takes a parameter specifying the type and location of an HV switch, which is expected to safely place 12V on the UPDI line when active. `-hv dtr` pulses the DTR line for 10ms. `-hv gpio:[-]portnum` opens a GPIO port and sets it active (low if - prefix is provided, high otherwise) for 10ms, then sets it inactive and closes it. This is longer than the datasheet specifies.

Tested on an Orange Pi Zero with a hacked-together programming circuit on a Tiny402, using GPIO mode. DTR wasn't tested because I burned my last USB-serial adapter while working on this. D'oh. Python isn't my first language so style notes are accepted.