### PR TITLE
Add setup.py for installations via pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,9 @@ pyupdi is a Python utility for programming AVR devices with UPDI interface
 When running pyupdi on Raspberry pi, use GPIOs 14 and 15 for UART TX and RX.
 On rpi3, be sure to apply the device tree overlay to map UART0/ttyAMA0 to these pins (relocate or disable Bluetooth device).
 More information here: https://www.raspberrypi.org/documentation/configuration/uart.md
+
+## install
+
+Install `pyupdi.py` with `pip` directly from GitHub:
+
+    pip install https://github.com/mraardvark/pyupdi/archive/master.zip

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+from setuptools import setup, find_packages
+
+name = "pyupdi"
+author = "mraardvark"
+url = "https://github.com/%s/%s" % (author, name)
+
+setup(
+    name = name,
+    author = author,
+    url = url,
+    scripts = [name + ".py"],
+    packages = find_packages(),
+    python_requires = '>3',
+    install_requires = [r.strip() for r in open("requirements.txt").readlines()]
+)


### PR DESCRIPTION
This way you can install the tool directly from a GitHub archive and it is placed in your `PATH` if you have `pip` configured correctly:

    pip install https://github.com/mraardvark/pyupdi/archive/master.zip

I have omitted versioning, since the repository does not have any tags yet. This PR is only meant to ease installations.