### PR TITLE
Suggest 1k instead of 4k7 resistor

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ pyupdi is a Python utility for programming AVR devices with UPDI interface
  +---------------------+ |                       | +--------------------+
  | Serial port         +-+                       +-+  AVR device        |
  |                     |      +----------+         |                    |
- |                  TX +------+   4k7    +---------+ UPDI               |
+ |                  TX +------+   1k     +---------+ UPDI               |
  |                     |      +----------+    |    |                    |
  |                     |                      |    |                    |
  |                  RX +----------------------+    |                    |


### PR DESCRIPTION
I have found that UPDI communication does not work correctly when using a 4k7 resistor against some chips using some kinds of USB-UART adapter.

In particular in my setup, using a CP2102 to talk to an AVR64DA48. The USB-UART chip has a signalling voltage of 3.6V, but powers the chip at 5V. In this setup, communication does not work with a 4k7 resistor, but works fine with the smaller 1k resistor. 4k7 is fine if signalling voltage matches VCC, but that might not always be possible to achieve. Almost every USB-UART adapter will actually signal at 3.3 or 3.6V, even if it is supplying 5V. This effect also seems specific to the AVR DA chips; the earlier chips (for example ATtiny1616 or ATmega3208) work just fine with these mixed voltages and 4k7 resistor.

In summary, it seems the specific combination of AVR DA chip, 4k7 resistor, mixed VCC/signalling voltage is problematic. Fixing any one of those three is enough to make things work reliably. Since a 1k resistor otherwise works fine in any other situation anyway, I would suggest using that instead.